### PR TITLE
Parcer qoutes handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,8 @@ SRCS = src/main.c\
 		src/builtin/env_var_parser.c \
 		src/builtin/export_var.c \
 		src/builtin/print_envp.c \
-		src/builtin/unset_var.c 
+		src/builtin/unset_var.c \
+		src/parcer_utils.c \
 
 OBJS = $(SRCS:.c=.o)
 LIBFT = libft/libft.a

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -50,7 +50,7 @@ void		free_parsed_commands(t_data **commands);
 char		*find_command(char *cmd, char **envp);
 void		free_split(char **args);
 void		error_exit(const char *message);
-char		**ft_split_quotes(const char *input);
+char        **ft_split_quotes(const char *input, t_data *data);
 void		free_structure(t_data *command);
 
 // Функции для работы с переменными окружения

--- a/outfile.txt
+++ b/outfile.txt
@@ -1,1 +1,0 @@
-/home/mikerf/projects_group/minishell

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+MINISHELL=./minishell # Path to the minishell executable
+TEST_FILE=tests.txt   # Path to the test file
+
+if [[ ! -f "$MINISHELL" ]]; then
+    echo "Error: $MINISHELL not found!"
+    exit 1
+fi
+
+if [[ ! -f "$TEST_FILE" ]]; then
+    echo "Error: $TEST_FILE not found!"
+    exit 1
+fi
+
+# Colors for output
+GREEN="\033[0;32m"
+RED="\033[0;31m"
+NC="\033[0m" # No Color
+
+# Counters
+TESTS_RUN=0
+TESTS_PASSED=0
+
+# Read tests from the file
+while IFS= read -r LINE; do
+    # Skip empty lines and comments
+    if [[ -z "$LINE" || "$LINE" == "#"* ]]; then
+        continue
+    fi
+
+    # Parse the input and expected output
+    if [[ "$LINE" == input:* ]]; then
+        COMMAND="${LINE#input: }" # Extract the command after "input:"
+    elif [[ "$LINE" == expected:* ]]; then
+        EXPECTED_OUTPUT="${LINE#expected: }" # Extract the output after "expected:"
+
+        # Run the command in minishell and capture the full output
+        FULL_OUTPUT=$(echo "$COMMAND" | "$MINISHELL" 2>/dev/null)
+
+        # Filter the actual output: remove lines with "minishell$"
+        ACTUAL_OUTPUT=$(echo "$FULL_OUTPUT" | sed '/^minishell\$ /d' | sed '/^$/d' | tr -d '\r')
+
+        # Increment the test counter
+        TESTS_RUN=$((TESTS_RUN + 1))
+
+        # Compare actual and expected output
+        if [[ "$ACTUAL_OUTPUT" == "$EXPECTED_OUTPUT" ]]; then
+            echo -e "${GREEN}Test $TESTS_RUN passed!${NC} Command: $COMMAND"
+            TESTS_PASSED=$((TESTS_PASSED + 1))
+        else
+            echo -e "${RED}Test $TESTS_RUN failed!${NC} Command: $COMMAND"
+            echo "Expected: $EXPECTED_OUTPUT"
+            echo "Actual:   $ACTUAL_OUTPUT"
+        fi
+    fi
+done < "$TEST_FILE"
+
+# Final statistics
+echo -e "\n$TESTS_RUN tests run. ${GREEN}$TESTS_PASSED passed.${NC} ${RED}$((TESTS_RUN - TESTS_PASSED)) failed.${NC}"

--- a/src/builtin/env_var_parser.c
+++ b/src/builtin/env_var_parser.c
@@ -6,7 +6,7 @@
 /*   By: artemii <artemii@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/25 00:06:31 by artemii           #+#    #+#             */
-/*   Updated: 2024/11/10 19:18:01 by artemii          ###   ########.fr       */
+/*   Updated: 2024/11/18 00:36:07 by artemii          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -111,16 +111,22 @@ char	*replace_env_var(char *input, t_data *data)
 	char	*result;
 	int		i;
 
-	i = 0;
-	result = ft_strdup(input);
-	if (!result)
-		return (NULL);
-	while (result[i] != '\0')
-	{
-		if (result[i] == '$')
-			result = process_variable(result, &i, data);
-		else
-			i++;
-	}
+    i = 0;
+    result = ft_strdup(input);
+    if (!result)
+        return (NULL);
+    while (result[i] != '\0')
+    {
+        if (result[i] == '\\')  // Если найден символ `\`
+        {
+            i++;  // Пропускаем его
+            continue;
+        }
+        if (result[i] == '$')  // Обрабатываем переменные окружения
+            result = process_variable(result, &i, data);
+        else
+            i++;
+    }
 	return (result);
 }
+

--- a/src/builtin/exec_builtin.c
+++ b/src/builtin/exec_builtin.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   exec_builtin.c                                     :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: mmychaly <mmychaly@student.42.fr>          +#+  +:+       +#+        */
+/*   By: artemii <artemii@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/06 04:50:13 by mmychaly          #+#    #+#             */
-/*   Updated: 2024/11/13 22:10:28 by mmychaly         ###   ########.fr       */
+/*   Updated: 2024/11/16 19:23:11 by artemii          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,18 +14,22 @@
 
 void	execute_builtin_command(t_data *data)
 {
-	char **args = data->cmd[data->i]->cmd_arg;
-	
-	if (ft_strcmp(data->cmd[data->i]->cmd, "echo") == 0)
-		echo(data);
-	else if (ft_strcmp(data->cmd[data->i]->cmd, "exit") == 0)
+	char	**args;
+
+	if (data->cmd[data->i] && data->cmd[data->i]->cmd)
+	{
+		args = data->cmd[data->i]->cmd_arg;
+		if (ft_strcmp(data->cmd[data->i]->cmd, "echo") == 0)
+			echo(data);
+		else if (ft_strcmp(data->cmd[data->i]->cmd, "exit") == 0)
 			exit_total(data);
-    else if (ft_strcmp(args[0], "export") == 0)
-		export_var(data, args[1]);
-    else if (ft_strcmp(args[0], "unset") == 0 )
-        unset_var(data, args[1]); // Удаляем переменную
-    else if (ft_strcmp(args[0], "env") == 0)
-		print_env(data);
-	else if (ft_strcmp(args[0], "pwd") == 0)
-		pwd(data);
+		else if (ft_strcmp(args[0], "export") == 0)
+			export_var(data, args[1]);
+		else if (ft_strcmp(args[0], "unset") == 0)
+			unset_var(data, args[1]); // Удаляем переменную
+		else if (ft_strcmp(args[0], "env") == 0)
+			print_env(data);
+		else if (ft_strcmp(args[0], "pwd") == 0)
+			pwd(data);
+	}
 }

--- a/src/main.c
+++ b/src/main.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: mmychaly <mmychaly@student.42.fr>          +#+  +:+       +#+        */
+/*   By: artemii <artemii@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/05 16:16:35 by azakharo          #+#    #+#             */
-/*   Updated: 2024/11/13 05:05:49 by mmychaly         ###   ########.fr       */
+/*   Updated: 2024/11/18 00:37:14 by artemii          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -189,6 +189,11 @@ int	main(int argc, char **argv, char **envp)
 		data->exit_status = exit_status; //Перед запуском новой команды подгружаем статус старой команды
 		print_commands(data);    // Вывод команд для дебага
 		printf("\n---------\n"); //Отделяем вывод команды от дебага
+		if (!data->cmd)
+   		{
+        	free(data->user_input);
+       		 continue; // Пропускаем выполнение команды
+  		}
 		choice_execution(data);
 		printf("status %i\n", data->exit_status);
 		exit_status = data->exit_status; //Сохраняем статус завершения команды перед освобождением

--- a/src/parcer_utils.c
+++ b/src/parcer_utils.c
@@ -1,0 +1,157 @@
+#include "../include/minishell.h"
+
+static void	skip_spaces(const char *str, int *i)
+{
+	while (str[*i] && str[*i] == ' ')
+		(*i)++;
+}
+// Функция возвразает строчку без кавычек
+static char	*extract_quoted_token(const char *str, int *i, char quote_char)
+{
+	int	start;
+
+	start = ++(*i);
+	while (str[*i] && str[*i] != quote_char)
+		(*i)++;
+	if (str[*i] == quote_char)
+		(*i)++;
+	return (ft_strndup(str + start, (*i) - start - 1));
+}
+
+// Для сборки в одну строку
+static char	*merge_tokens(char *first, char *second)
+{
+	char	*merged;
+
+	merged = ft_strjoin(first, second);
+	free(first);
+	free(second);
+	if (!merged)
+	{
+		perror("malloc");
+		exit(EXIT_FAILURE);
+	}
+	return (merged);
+}
+
+static char	*handle_quotes(const char *str, int *i, t_data *data, char *result)
+{
+	char	quote_char;
+	char	*token;
+	char	*expanded;
+
+	quote_char = str[*i];
+	token = extract_quoted_token(str, i, quote_char);
+	if (quote_char == '"') // Для двойных кавычек обрабатываем переменные
+	{
+		expanded = replace_env_var(token, data);
+		free(token);
+		token = expanded;
+	}
+	if (result == NULL)
+		result = token;
+	else
+		result = merge_tokens(result, token);
+	return (result);
+}
+
+// Для подстановки переменной
+static char	*handle_variable(const char *str, int *i, t_data *data,
+		char *result)
+{
+	int		start;
+	char	*var;
+	char	*expanded;
+
+	start = (*i)++;
+	while (str[*i] && (ft_isalnum(str[*i]) || str[*i] == '_'))
+		(*i)++;
+	var = ft_strndup(str + start, *i - start);
+	expanded = replace_env_var(var, data);
+	free(var);
+	if (result == NULL)
+		result = expanded;
+	else
+		result = merge_tokens(result, expanded);
+	return (result);
+}
+
+// Удаляет бэкслэш
+static char	*handle_backslash(const char *str, int *i, char *result)
+{
+	char	*escaped;
+
+	(*i)++;
+	if (str[*i])
+		escaped = ft_strndup(str + (*i)++, 1);
+	else
+		escaped = ft_strdup("");
+	if (result == NULL)
+		result = escaped;
+	else
+		result = merge_tokens(result, escaped);
+	return (result);
+}
+
+//Добавляем к итоговой строке обычный текст
+static char	*handle_text(const char *str, int *i, char *result)
+{
+	int		start;
+	char	*text;
+
+	start = *i;
+	while (str[*i] && !ft_strchr(" '$\"\\", str[*i])) 		// Пока не встречаем спецсимвол
+		(*i)++;
+	text = ft_strndup(str + start, *i - start);
+	if (result == NULL)
+		result = text;
+	else
+		result = merge_tokens(result, text);
+	return (result);
+}
+
+static char	*process_token(const char *str, int *i, t_data *data)
+{
+	char	*result;
+
+	result = NULL;
+	while (str[*i] && str[*i] != ' ')
+	{
+		if (str[*i] == '\'' || str[*i] == '"')
+			result = handle_quotes(str, i, data, result);
+		else if (str[*i] == '$')
+			result = handle_variable(str, i, data, result);
+		else if (str[*i] == '\\')
+			result = handle_backslash(str, i, result);
+		else
+			result = handle_text(str, i, result);
+	}
+	return (result);
+}
+
+char	**ft_split_quotes(const char *input, t_data *data)
+{
+	char	**tokens;
+	int		i;
+	int		token_count;
+
+	i = 0;
+	token_count = 0;
+	if (!input || !data)
+		return (NULL);
+	tokens = malloc(sizeof(char *) * (ft_strlen(input) / 2 + 2));
+	if (!tokens)
+	{
+		perror("malloc");
+		exit(EXIT_FAILURE);
+	}
+	while (input[i])
+	{
+		skip_spaces(input, &i);
+		if (input[i]) // Если есть что парсить
+			tokens[token_count++] = process_token(input, &i, data);
+		skip_spaces(input, &i);
+	}
+	tokens[token_count] = NULL;
+	return (tokens);
+}

--- a/src/parser.c
+++ b/src/parser.c
@@ -48,7 +48,15 @@ void	handle_command_args(t_cmd *cmd, char **tokens, int *i, int *arg_idx)
 	if (cmd->cmd_arg == NULL)
 	{
 		cmd->cmd_arg = malloc(sizeof(char *) * 100);
+		if (!cmd->cmd_arg)
+			return ;
 		cmd->cmd = ft_strdup(tokens[*i]);
+		if (!cmd->cmd)
+		{
+			free(cmd->cmd_arg);
+			cmd->cmd_arg = NULL;
+			return ;
+		}
 	}
 	cmd->cmd_arg[(*arg_idx)++] = ft_strdup(tokens[*i]);
 }
@@ -74,53 +82,61 @@ void	parse_single_command(t_cmd *cmd, char *input)
 			handle_command_args(cmd, tokens, &i, &arg_idx);
 		i++;
 	}
-	cmd->cmd_arg[arg_idx] = NULL;
+	if (arg_idx == 0) // Если аргументы отсутствуют
+	{
+		cmd->cmd_arg = NULL;
+		cmd->cmd = NULL; // Убедимся, что cmd остается пустым
+	}
+	else
+		cmd->cmd_arg[arg_idx] = NULL;
 	free_split(tokens);
 }
 
 // Парсинг пайплайна команд
-void parse_pipeline(t_data *data, char *input)
+void	parse_pipeline(t_data *data, char *input)
 {
-    char *processed_input = replace_env_var(input, data);
-    char **command_tokens;
-    int cmd_count = 0;
-    int i = 0;
+	char	*processed_input;
+	char	**command_tokens;
+	int		cmd_count;
+	int		i;
 
-    if (!processed_input)
-        return;
-
-    command_tokens = ft_split(processed_input, '|');
-    if (!command_tokens) {
-        free(processed_input); // Освобождаем, если ft_split не удалось
-        return;
-    }
-
-    while (command_tokens[cmd_count] != NULL)
-        cmd_count++;
-    
-    data->cmd = malloc(sizeof(t_cmd *) * (cmd_count + 1));
-    if (!data->cmd) {
-        free(processed_input);
-        free_split(command_tokens);
-        return;
-    }
-
-    data->nb_pipe = cmd_count - 1;
-    while (i < cmd_count) {
-        data->cmd[i] = malloc(sizeof(t_cmd));
-        if (!data->cmd[i]) {
-            perror("malloc failed");
-            free(processed_input);
-            free_split(command_tokens);
-            free_data_cmd(data);  // Освобождаем всё, если выделение не удалось
-            return;
-        }
-        ft_memset(data->cmd[i], 0, sizeof(t_cmd));
-        parse_single_command(data->cmd[i], command_tokens[i]);
-        i++;
-    }
-    data->cmd[cmd_count] = NULL;
-    free_split(command_tokens);
-    free(processed_input);
+	processed_input = replace_env_var(input, data);
+	cmd_count = 0;
+	i = 0;
+	if (!processed_input)
+		return ;
+	command_tokens = ft_split(processed_input, '|');
+	if (!command_tokens)
+	{
+		free(processed_input); // Освобождаем, если ft_split не удалось
+		return ;
+	}
+	while (command_tokens[cmd_count] != NULL)
+		cmd_count++;
+	data->cmd = malloc(sizeof(t_cmd *) * (cmd_count + 1));
+	if (!data->cmd)
+	{
+		free(processed_input);
+		free_split(command_tokens);
+		return ;
+	}
+	data->nb_pipe = cmd_count - 1;
+	while (i < cmd_count)
+	{
+		data->cmd[i] = malloc(sizeof(t_cmd));
+		if (!data->cmd[i])
+		{
+			perror("malloc failed");
+			free(processed_input);
+			free_split(command_tokens);
+			free_data_cmd(data); // Освобождаем всё, если выделение не удалось
+			return ;
+		}
+		ft_memset(data->cmd[i], 0, sizeof(t_cmd));
+		parse_single_command(data->cmd[i], command_tokens[i]);
+		i++;
+	}
+	data->cmd[cmd_count] = NULL;
+	free_split(command_tokens);
+	free(processed_input);
 }
-

--- a/src/utils.c
+++ b/src/utils.c
@@ -65,49 +65,4 @@ void	error_exit(const char *message)
 	exit(EXIT_FAILURE);
 }
 
-static void skip_spaces(const char *str, int *i)
-{
-    while (str[*i] && str[*i] == ' ')
-        (*i)++;
-}
 
-static char *get_token_in_quotes(const char *str, int *i, char quote_char)
-{
-    int start = ++(*i);
-    while (str[*i] && str[*i] != quote_char)
-        (*i)++;
-    if (str[*i] == quote_char)
-        (*i)++;
-    
-    char *token = ft_strndup(str + start, (*i) - start - 1);
-    return token;
-}
-
-char **ft_split_quotes(const char *input)
-{
-    char **tokens = malloc(sizeof(char *) * (ft_strlen(input) / 2 + 2)); // например половина строки + запас
-    int i = 0;
-    int token_count = 0;
-
-    while (input[i])
-    {
-        skip_spaces(input, &i);
-
-        if (input[i] == '\'' || input[i] == '"')  // Если начинается с кавычки
-        {
-            char quote_char = input[i];
-            tokens[token_count++] = get_token_in_quotes(input, &i, quote_char);
-        }
-        else  // Если это обычный токен без кавычек
-        {
-            int start = i;
-            while (input[i] && input[i] != ' ' && input[i] != '\'' && input[i] != '"')
-                i++;
-            tokens[token_count++] = ft_strndup(input + start, i - start);
-        }
-
-        skip_spaces(input, &i);
-    }
-    tokens[token_count] = NULL;  // Завершаем массив токенов
-    return tokens;
-}

--- a/test.txt
+++ b/test.txt
@@ -1,8 +1,0 @@
-Hello minishell !
-1
-2
-3 777
-4
-5
-6
-7

--- a/tests.txt
+++ b/tests.txt
@@ -1,0 +1,47 @@
+# Test 1: Single quotes prevent interpretation of special characters
+input: echo 'Special characters: $USER; ls;'
+expected: Special characters: $USER; ls;
+
+# Test 2: Double quotes allow variable expansion but prevent interpretation of other metacharacters
+input: echo "Home directory: $HOME"
+expected: Home directory: /home/artemii
+
+# Test 3: Escaped special characters within double quotes
+input: echo \$HOME
+expected: $HOME
+
+# Test 4: Semicolon at the end of the line
+input: echo This is a test ;
+expected: This is a test ;
+
+# Test 5: Backslash at the end of the line (line continuation)
+input: echo This is a test \
+expected: This is a test 
+
+# Test 6: Unclosed single quote
+input: echo "directory is $HOME"
+expected: directory is /home/artemii
+
+# Test 7: Unclosed double quote
+input: echo 'directory is $HOME'
+expected: directory is $HOME
+
+# Test 8: Mixed quotes to produce a single word
+input: "e"'c'ho 'b'"o"nj"o"'u'r 
+expected: bonjour
+
+# Test 9: Mixed quotes to produce a single word
+input: echo 'Home is "$HOME"' 
+expected: Home is "$HOME"
+
+# Test 10: Mixed quotes to produce a single word
+input: echo $USER$var\$USER$USER\$USERtest$USER 
+expected: artemii$USERartemii$USERtestartemii
+
+# Test 11: Error: unclosed quotes '
+input: echo 'hello 
+expected: Error: unclosed quotes
+
+# Test 12: Error: unclosed quotes "
+input: echo "hello 
+expected: Error: unclosed quotes


### PR DESCRIPTION
Сделал обработку пунктов

> Not interpret unclosed quotes or special characters which are not required by the
 subject such as \ (backslash) or ; (semicolon).
>  Handle ’ (single quote) which should prevent the shell from interpreting the metacharacters in the quoted sequence.
> Handle " (double quote) which should prevent the shell from interpreting the metacharacters in the quoted sequence except for $ (dollar sign).

Я сделал тестовый скрипт, там немного тестов из [доки](https://docs.google.com/spreadsheets/d/1uJHQu0VPsjjBkR4hxOeCMEt3AOM1Hp_SmUzPFhAH-nA/htmlview#gid=0)
Чтобы его запустить надо
1. Закомментировать наш дебаг вывод (строчки 190,191,198)
2. make
3. запустить ./run_tests.sh 
4. Запустятся тесты из файла tests.txt (Будем его расширять).